### PR TITLE
Update requirement.txt

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,4 +1,4 @@
-cython
+cython=0.29.20
 chumpy==0.70 
 scikit-image==0.18.1
 torch==1.9.1


### PR DESCRIPTION
Kaolin 0.10.0 installation fails with "ImportError: Kaolin requires cython == 0.29.20, but found version 0.29.34 instead."